### PR TITLE
Fix #104 : Fatal exception in sample if try to pick file without file manager

### DIFF
--- a/sample/src/main/java/com/github/barteksc/sample/PDFViewActivity.java
+++ b/sample/src/main/java/com/github/barteksc/sample/PDFViewActivity.java
@@ -15,12 +15,14 @@
  */
 package com.github.barteksc.sample;
 
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.OpenableColumns;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.github.barteksc.pdfviewer.PDFView;
 import com.github.barteksc.pdfviewer.listener.OnLoadCompleteListener;
@@ -63,7 +65,13 @@ public class PDFViewActivity extends AppCompatActivity implements OnPageChangeLi
     void pickFile() {
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.setType("application/pdf");
-        startActivityForResult(intent, REQUEST_CODE);
+        try {
+            startActivityForResult(intent, REQUEST_CODE);
+        }
+        catch (ActivityNotFoundException e) {
+            //alert user that file manager not working
+            Toast.makeText(this, R.string.toast_pick_file_error, Toast.LENGTH_SHORT).show();
+        }
     }
 
     @AfterViews

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">AndroidPdfViewer demo</string>
     <string name="pick_file">Pick file</string>
+    <string name="toast_pick_file_error">Unable to pick file. Check status of file manager.</string>
 </resources>


### PR DESCRIPTION
This resolves #104 : Fatal exception in sample if try to pick file without file manager. Many users won't have a file manager installed on their phones by default. Resolved issue by catching exception and displaying Toast.
