### PR TITLE
Fixes #106: Sample fails to load files due to lack of permission request during app

### DIFF
--- a/sample/src/main/java/com/github/barteksc/sample/PDFViewActivity.java
+++ b/sample/src/main/java/com/github/barteksc/sample/PDFViewActivity.java
@@ -16,9 +16,12 @@
 package com.github.barteksc.sample;
 
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.OpenableColumns;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
@@ -45,8 +48,10 @@ public class PDFViewActivity extends AppCompatActivity implements OnPageChangeLi
     private static final String TAG = PDFViewActivity.class.getSimpleName();
 
     private final static int REQUEST_CODE = 42;
+    public static final int PERMISSION_CODE = 42042;
 
     public static final String SAMPLE_FILE = "sample.pdf";
+    public static final String READ_EXTERNAL_STORAGE = "android.permission.READ_EXTERNAL_STORAGE";
 
     @ViewById
     PDFView pdfView;
@@ -61,6 +66,23 @@ public class PDFViewActivity extends AppCompatActivity implements OnPageChangeLi
 
     @OptionsItem(R.id.pickFile)
     void pickFile() {
+        int permissionCheck = ContextCompat.checkSelfPermission(this,
+                READ_EXTERNAL_STORAGE);
+
+        if (permissionCheck != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(
+                    this,
+                    new String[]{READ_EXTERNAL_STORAGE},
+                    PERMISSION_CODE
+            );
+
+            return;
+        }
+
+        launchPicker();
+    }
+
+    void launchPicker() {
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.setType("application/pdf");
         startActivityForResult(intent, REQUEST_CODE);
@@ -160,4 +182,22 @@ public class PDFViewActivity extends AppCompatActivity implements OnPageChangeLi
             }
         }
     }
+
+    /**
+     * Listener for response to user permission request
+     * @param requestCode Check that permission request code matches
+     * @param permissions Permissions that requested
+     * @param grantResults Whether permissions granted
+     */
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String permissions[],
+                                           int[] grantResults) {
+        if (requestCode == PERMISSION_CODE) {
+            if (grantResults.length > 0
+                    && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                launchPicker();
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
This resolves #106 : Sample fails to load files due to lack of permission request during app. This is necessary for API level 23 or above. Fixed by requesting permission during app run.
