### PR TITLE
Replaces RenderingAsyncTask with RenderingHandler

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -686,7 +686,8 @@ public class PDFView extends RelativeLayout {
         if (!renderingHandlerThread.isAlive()) {
             renderingHandlerThread.start();
         }
-        renderingHandler = new RenderingHandler(this, pdfiumCore, pdfDocument);
+        renderingHandler = new RenderingHandler(renderingHandlerThread.getLooper(),
+                this, pdfiumCore, pdfDocument);
 
         if (scrollHandle != null) {
             scrollHandle.setupLayout(this);

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PagesLoader.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PagesLoader.java
@@ -87,7 +87,7 @@ class PagesLoader {
     private void loadThumbnail(int userPage, int documentPage) {
         if (!pdfView.cacheManager.containsThumbnail(userPage, documentPage,
                 thumbnailWidth, thumbnailHeight, thumbnailRect)) {
-            pdfView.renderingAsyncTask.addRenderingTask(userPage, documentPage,
+            pdfView.renderingHandler.addRenderingTask(userPage, documentPage,
                     thumbnailWidth, thumbnailHeight, thumbnailRect,
                     true, 0, pdfView.isBestQuality(), pdfView.isAnnotationRendering());
         }
@@ -218,7 +218,7 @@ class PagesLoader {
 
         if (renderWidth > 0 && renderHeight > 0) {
             if (!pdfView.cacheManager.upPartIfContained(userPage, documentPage, renderWidth, renderHeight, pageRelativeBounds, cacheOrder)) {
-                pdfView.renderingAsyncTask.addRenderingTask(userPage, documentPage,
+                pdfView.renderingHandler.addRenderingTask(userPage, documentPage,
                         renderWidth, renderHeight, pageRelativeBounds, false, cacheOrder,
                         pdfView.isBestQuality(), pdfView.isAnnotationRendering());
             }

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/RenderingHandler.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/RenderingHandler.java
@@ -19,24 +19,30 @@ import android.graphics.Bitmap;
 import android.graphics.Matrix;
 import android.graphics.Rect;
 import android.graphics.RectF;
-import android.os.AsyncTask;
+import android.os.Handler;
+import android.os.Message;
 
 import com.github.barteksc.pdfviewer.model.PagePart;
 import com.shockwave.pdfium.PdfDocument;
 import com.shockwave.pdfium.PdfiumCore;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
-class RenderingAsyncTask extends AsyncTask<Void, PagePart, Void> {
+/**
+ * A {@link Handler} that will process incoming {@link RenderingTask} messages
+ * and alert {@link PDFView#onBitmapRendered(PagePart)} when the portion of the
+ * PDF is ready to render.
+ */
+class RenderingHandler extends Handler {
+    /**
+     * {@link Message#what} kind of message this handler processes.
+     */
+    static final int MSG_RENDER_TASK = 1;
 
     private PdfiumCore pdfiumCore;
     private PdfDocument pdfDocument;
 
-    private final List<RenderingTask> renderingTasks;
     private PDFView pdfView;
 
     private RectF renderBounds = new RectF();
@@ -44,70 +50,24 @@ class RenderingAsyncTask extends AsyncTask<Void, PagePart, Void> {
     private Matrix renderMatrix = new Matrix();
     private final Set<Integer> openedPages = new HashSet<>();
 
-    public RenderingAsyncTask(PDFView pdfView, PdfiumCore pdfiumCore, PdfDocument pdfDocument) {
+    RenderingHandler(PDFView pdfView, PdfiumCore pdfiumCore, PdfDocument pdfDocument) {
         this.pdfView = pdfView;
         this.pdfiumCore = pdfiumCore;
         this.pdfDocument = pdfDocument;
-        this.renderingTasks = Collections.synchronizedList(new ArrayList<RenderingTask>());
-
     }
 
-    public void addRenderingTask(int userPage, int page, float width, float height, RectF bounds, boolean thumbnail, int cacheOrder, boolean bestQuality, boolean annotationRendering) {
+    void addRenderingTask(int userPage, int page, float width, float height, RectF bounds, boolean thumbnail, int cacheOrder, boolean bestQuality, boolean annotationRendering) {
         RenderingTask task = new RenderingTask(width, height, bounds, userPage, page, thumbnail, cacheOrder, bestQuality, annotationRendering);
-        renderingTasks.add(task);
-        wakeUp();
+        Message msg = obtainMessage(MSG_RENDER_TASK, task);
+        sendMessage(msg);
     }
 
     @Override
-    protected Void doInBackground(Void... params) {
-        while (!isCancelled()) {
-
-            // Proceed all tasks
-            while (true) {
-                RenderingTask task;
-                synchronized (renderingTasks) {
-                    if (!renderingTasks.isEmpty()) {
-                        task = renderingTasks.get(0);
-                    } else {
-                        break;
-                    }
-                }
-                //it is very rare case, but sometimes null can appear
-                if (task != null) {
-                    PagePart part = proceed(task);
-                    if (part == null) {
-                        break;
-                    } else if (renderingTasks.remove(task)) {
-                        publishProgress(part);
-                    } else {
-                        part.getRenderedBitmap().recycle();
-                    }
-                }
-            }
-
-            // Wait for new task, return if canceled
-            if (!waitForRenderingTasks() || isCancelled()) {
-                return null;
-            }
-
-        }
-        return null;
-
-    }
-
-    @Override
-    protected void onProgressUpdate(PagePart... part) {
-        pdfView.onBitmapRendered(part[0]);
-    }
-
-    private boolean waitForRenderingTasks() {
-        try {
-            synchronized (renderingTasks) {
-                renderingTasks.wait();
-            }
-            return true;
-        } catch (InterruptedException e) {
-            return false;
+    public void handleMessage(Message message) {
+        RenderingTask task = (RenderingTask) message.obj;
+        PagePart part = proceed(task);
+        if (part != null) {
+            pdfView.onBitmapRendered(part);
         }
     }
 
@@ -121,15 +81,9 @@ class RenderingAsyncTask extends AsyncTask<Void, PagePart, Void> {
         int h = Math.round(renderingTask.height);
         Bitmap render = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
         calculateBounds(w, h, renderingTask.bounds);
-
-        if (!isCancelled()) {
-            pdfiumCore.renderPageBitmap(pdfDocument, render, renderingTask.page,
-                    roundedRenderBounds.left, roundedRenderBounds.top,
-                    roundedRenderBounds.width(), roundedRenderBounds.height(), renderingTask.annotationRendering);
-        } else {
-            render.recycle();
-            return null;
-        }
+        pdfiumCore.renderPageBitmap(pdfDocument, render, renderingTask.page,
+                roundedRenderBounds.left, roundedRenderBounds.top,
+                roundedRenderBounds.width(), roundedRenderBounds.height(), renderingTask.annotationRendering);
 
         if (!renderingTask.bestQuality) {
             Bitmap cpy = render.copy(Bitmap.Config.RGB_565, false);
@@ -153,18 +107,6 @@ class RenderingAsyncTask extends AsyncTask<Void, PagePart, Void> {
         renderBounds.round(roundedRenderBounds);
     }
 
-    public void removeAllTasks() {
-        synchronized (renderingTasks) {
-            renderingTasks.clear();
-        }
-    }
-
-    public void wakeUp() {
-        synchronized (renderingTasks) {
-            renderingTasks.notify();
-        }
-    }
-
     private class RenderingTask {
 
         float width, height;
@@ -183,8 +125,7 @@ class RenderingAsyncTask extends AsyncTask<Void, PagePart, Void> {
 
         boolean annotationRendering;
 
-        public RenderingTask(float width, float height, RectF bounds, int userPage, int page, boolean thumbnail, int cacheOrder, boolean bestQuality, boolean annotationRendering) {
-            super();
+        RenderingTask(float width, float height, RectF bounds, int userPage, int page, boolean thumbnail, int cacheOrder, boolean bestQuality, boolean annotationRendering) {
             this.page = page;
             this.width = width;
             this.height = height;
@@ -195,7 +136,5 @@ class RenderingAsyncTask extends AsyncTask<Void, PagePart, Void> {
             this.bestQuality = bestQuality;
             this.annotationRendering = annotationRendering;
         }
-
     }
-
 }

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/RenderingHandler.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/RenderingHandler.java
@@ -20,6 +20,7 @@ import android.graphics.Matrix;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.Message;
 
 import com.github.barteksc.pdfviewer.model.PagePart;
@@ -50,7 +51,8 @@ class RenderingHandler extends Handler {
     private Matrix renderMatrix = new Matrix();
     private final Set<Integer> openedPages = new HashSet<>();
 
-    RenderingHandler(PDFView pdfView, PdfiumCore pdfiumCore, PdfDocument pdfDocument) {
+    RenderingHandler(Looper looper, PDFView pdfView, PdfiumCore pdfiumCore, PdfDocument pdfDocument) {
+        super(looper);
         this.pdfView = pdfView;
         this.pdfiumCore = pdfiumCore;
         this.pdfDocument = pdfDocument;
@@ -65,9 +67,14 @@ class RenderingHandler extends Handler {
     @Override
     public void handleMessage(Message message) {
         RenderingTask task = (RenderingTask) message.obj;
-        PagePart part = proceed(task);
+        final PagePart part = proceed(task);
         if (part != null) {
-            pdfView.onBitmapRendered(part);
+            pdfView.post(new Runnable() {
+                @Override
+                public void run() {
+                    pdfView.onBitmapRendered(part);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Hi! The current version of AndroidPdfViewer was causing my Espresso tests to hang forever. It turns keeping an AsyncTask around forever was preventing Espresso from proceeding. I replaced AsyncTask with a Handler.

The Handler has a built-in mechanism to handle new work coming in asynchronously. Now there's no need for locks, waiting and notifying threads that new work is available. The main loop (originally in doInBackground) went from being 50 lines to being 5 lines (in handleMessage).