### PR TITLE
Issue#195-fix request

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/AnimationManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/AnimationManager.java
@@ -87,17 +87,27 @@ class AnimationManager {
 
     public void stopAll() {
         if (animation != null) {
-            animation.cancel();
-            animation = null;
+            pdfView.post(new Runnable() {
+                @Override
+                public void run() {
+                    animation.cancel();
+                    animation = null;
+                }
+            });
         }
         stopFling();
     }
 
     public void stopFling() {
         if (flingAnimation != null) {
-            scroller.forceFinished(true);
-            flingAnimation.cancel();
-            flingAnimation = null;
+            pdfView.post(new Runnable() {
+                @Override
+                public void run() {
+                    scroller.forceFinished(true);
+                    flingAnimation.cancel();
+                    flingAnimation = null;
+                }
+            });
         }
     }
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -460,6 +460,7 @@ public class PDFView extends RelativeLayout {
 
         // Stop tasks
         if (renderingHandler != null) {
+            renderingHandler.forceStopProc();
             renderingHandler.removeMessages(RenderingHandler.MSG_RENDER_TASK);
         }
         if (decodingAsyncTask != null) {


### PR DESCRIPTION
Calling stop animations on view's thread (animation's render thread) and add flag to stop proccess current (not pending) messages in handler. Without flag, if some pages are renderng but you are call recycle, you will catch tons of handled nullpointers, and usually after unhandled nullpoiner, with crash of app.