### PR TITLE
(WIP) A solution for Issue #97. For PDF with variable page sizes, this change makes sure a page with …

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/CacheManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/CacheManager.java
@@ -92,7 +92,7 @@ class CacheManager {
     }
 
     public boolean upPartIfContained(int userPage, int page, float width, float height, RectF pageRelativeBounds, int toOrder) {
-        PagePart fakePart = new PagePart(userPage, page, null, width, height, pageRelativeBounds, false, 0);
+        PagePart fakePart = new PagePart(userPage, page, null, width, height, pageRelativeBounds, false, 0, 0, 0);
 
         PagePart found;
         synchronized (passiveActiveLock) {
@@ -111,7 +111,7 @@ class CacheManager {
      * Return true if already contains the described PagePart
      */
     public boolean containsThumbnail(int userPage, int page, float width, float height, RectF pageRelativeBounds) {
-        PagePart fakePart = new PagePart(userPage, page, null, width, height, pageRelativeBounds, true, 0);
+        PagePart fakePart = new PagePart(userPage, page, null, width, height, pageRelativeBounds, true, 0, 0, 0);
         synchronized (thumbnails) {
             for (PagePart part : thumbnails) {
                 if (part.equals(fakePart)) {

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/RenderingHandler.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/RenderingHandler.java
@@ -84,6 +84,9 @@ class RenderingHandler extends Handler {
             pdfiumCore.openPage(pdfDocument, renderingTask.page);
         }
 
+        int pageWidth = pdfiumCore.getPageWidth(pdfDocument, renderingTask.page);
+        int pageHeight = pdfiumCore.getPageHeight(pdfDocument, renderingTask.page);
+
         int w = Math.round(renderingTask.width);
         int h = Math.round(renderingTask.height);
         Bitmap render = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
@@ -101,7 +104,8 @@ class RenderingHandler extends Handler {
         return new PagePart(renderingTask.userPage, renderingTask.page, render, //
                 renderingTask.width, renderingTask.height, //
                 renderingTask.bounds, renderingTask.thumbnail, //
-                renderingTask.cacheOrder);
+                renderingTask.cacheOrder,
+                pageWidth, pageHeight);
     }
 
     private void calculateBounds(int width, int height, RectF pageSliceBounds) {

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/model/PagePart.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/model/PagePart.java
@@ -34,7 +34,9 @@ public class PagePart {
 
     private int cacheOrder;
 
-    public PagePart(int userPage, int page, Bitmap renderedBitmap, float width, float height, RectF pageRelativeBounds, boolean thumbnail, int cacheOrder) {
+    private int pageWidth, pageHeight;
+
+    public PagePart(int userPage, int page, Bitmap renderedBitmap, float width, float height, RectF pageRelativeBounds, boolean thumbnail, int cacheOrder, int pageWidth, int pageHeight) {
         super();
         this.userPage = userPage;
         this.page = page;
@@ -42,6 +44,16 @@ public class PagePart {
         this.pageRelativeBounds = pageRelativeBounds;
         this.thumbnail = thumbnail;
         this.cacheOrder = cacheOrder;
+        this.pageWidth = pageWidth;
+        this.pageHeight = pageHeight;
+    }
+
+    public int getPageWidth() {
+        return pageWidth;
+    }
+
+    public int getPageHeight() {
+        return pageHeight;
     }
 
     public int getCacheOrder() {


### PR DESCRIPTION
…different width and height scales while maintaining its aspect ratio.

A PDF page was rendered using the whole optimal height and width. This method is commonly referred as "Aspect Fill" or "Fill", which isn't normally what we want. This PR changed the rendering to be "Aspect Fit" so that pages with different width or height can render with same scaling ratio.