### PR TITLE
Bugfix:   pdfviewer will crash when users touch it before pdf is completely loaded

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -1005,6 +1005,9 @@ public class PDFView extends RelativeLayout {
     }
 
     void loadPageByOffset() {
+    	if(0==getPageCount()){
+            return ;
+        }
         float offset, optimal, screenCenter;
         float spacingPerPage = spacingPx - (spacingPx / getPageCount());
         if (swipeVertical) {

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -1005,7 +1005,7 @@ public class PDFView extends RelativeLayout {
     }
 
     void loadPageByOffset() {
-    	if(0==getPageCount()){
+    	if(0 == getPageCount()){
             return ;
         }
         float offset, optimal, screenCenter;


### PR DESCRIPTION
Fix the bug that the viewer will crash when the pdf file is not completely loaded:
Cause: the function---getPageCount() equals zero:         
float spacingPerPage = spacingPx - (spacingPx / getPageCount());
Dividing by zero will appear and it cause the app crash.