### PR TITLE
Check if pdfView != null

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/scroll/DefaultScrollHandle.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/scroll/DefaultScrollHandle.java
@@ -110,7 +110,9 @@ public class DefaultScrollHandle extends RelativeLayout implements ScrollHandle 
         } else {
             handler.removeCallbacks(hidePageScrollerRunnable);
         }
-        setPosition((pdfView.isSwipeVertical() ? pdfView.getHeight() : pdfView.getWidth()) * position);
+        if (pdfView != null) {
+            setPosition((pdfView.isSwipeVertical() ? pdfView.getHeight() : pdfView.getWidth()) * position);
+        }
     }
 
     private void setPosition(float pos) {


### PR DESCRIPTION
I am proposing a little fix that based on the my error by Crashlytics.

Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean com.github.barteksc.pdfviewer.PDFView.isSwipeVertical()' on a null object reference
       at com.github.barteksc.pdfviewer.scroll.DefaultScrollHandle.setScroll(DefaultScrollHandle.java:113)
       at com.github.barteksc.pdfviewer.PDFView.moveTo(PDFView.java:925)
       at com.github.barteksc.pdfviewer.PDFView.moveTo(PDFView.java:846)
       at com.github.barteksc.pdfviewer.PDFView.onSizeChanged(PDFView.java:539)
       at android.view.View.sizeChange(View.java:19011)
       at android.view.View.setFrame(View.java:18954)
       at android.view.View.layout(View.java:18867)
       at android.view.ViewGroup.layout(ViewGroup.java:5954)
       at android.widget.RelativeLayout.onLayout(RelativeLayout.java:1079)
       at android.view.View.layout(View.java:18874)
       at android.view.ViewGroup.layout(ViewGroup.java:5954)
       at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1741)
       at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1585)
       at android.widget.LinearLayout.onLayout(LinearLayout.java:1494)
       at android.view.View.layout(View.java:18874)
       at android.view.ViewGroup.layout(ViewGroup.java:5954)
       at android.widget.FrameLayout.layoutChildren(FrameLayout.java:323)
       at android.widget.FrameLayout.onLayout(FrameLayout.java:261)
       at android.view.View.layout(View.java:18874)
       at android.view.ViewGroup.layout(ViewGroup.java:5954)
       at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1741)
       at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1585)
       at android.widget.LinearLayout.onLayout(LinearLayout.java:1494)
       at android.view.View.layout(View.java:18874)
       at android.view.ViewGroup.layout(ViewGroup.java:5954)
       at android.widget.FrameLayout.layoutChildren(FrameLayout.java:323)
       at android.widget.FrameLayout.onLayout(FrameLayout.java:261)
       at android.view.View.layout(View.java:18874)
       at android.view.ViewGroup.layout(ViewGroup.java:5954)
       at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1741)
       at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1585)
       at android.widget.LinearLayout.onLayout(LinearLayout.java:1494)
       at android.view.View.layout(View.java:18874)
       at android.view.ViewGroup.layout(ViewGroup.java:5954)
       at android.widget.FrameLayout.layoutChildren(FrameLayout.java:323)
       at android.widget.FrameLayout.onLayout(FrameLayout.java:261)
       at com.android.internal.policy.DecorView.onLayout(DecorView.java:935)
       at android.view.View.layout(View.java:18874)
       at android.view.ViewGroup.layout(ViewGroup.java:5954)
       at android.view.ViewRootImpl.performLayout(ViewRootImpl.java:2697)
       at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2413)
       at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1550)
       at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7189)
       at android.view.Choreographer$CallbackRecord.run(Choreographer.java:959)
       at android.view.Choreographer.doCallbacks(Choreographer.java:734)
       at android.view.Choreographer.doFrame(Choreographer.java:670)
       at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:945)
       at android.os.Handler.handleCallback(Handler.java:751)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:154)
       at android.app.ActivityThread.main(ActivityThread.java:6776)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1520)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1410)