### PR TITLE
Crashing on PDF with a bad page.

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/RenderingHandler.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/RenderingHandler.java
@@ -86,7 +86,12 @@ class RenderingHandler extends Handler {
     private PagePart proceed(RenderingTask renderingTask) {
         if (!openedPages.contains(renderingTask.page)) {
             openedPages.add(renderingTask.page);
-            pdfiumCore.openPage(pdfDocument, renderingTask.page);
+            try {
+                pdfiumCore.openPage(pdfDocument, renderingTask.page);
+            } catch (Exception e) {
+                e.printStackTrace();
+                return null;
+            }
         }
 
         int w = Math.round(renderingTask.width);


### PR DESCRIPTION
Wrapped pdfiumCore.openPage() with a try catch to prevent an unrecoverable crash being passed on to the user. Ideally this should render an error page or give the user the option to show an error message. As it is now it just doesn't render anything and shows a black screen on the offending page

Attached is a PDF with a page that won't render. (page 7)
[test.pdf](https://github.com/barteksc/AndroidPdfViewer/files/1417172/test.pdf)
