### PR TITLE
Single page scrolling

### DIFF
--- a/android-pdf-viewer/build.gradle
+++ b/android-pdf-viewer/build.gradle
@@ -1,3 +1,4 @@
+//apply plugin: 'java'
 apply plugin: 'com.android.library'
 
 ext {
@@ -26,7 +27,7 @@ ext {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    //buildToolsVersion '25.0.3'
 
     defaultConfig {
         minSdkVersion 11

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/AnimationManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/AnimationManager.java
@@ -24,6 +24,8 @@ import android.graphics.PointF;
 import android.view.animation.DecelerateInterpolator;
 import android.widget.OverScroller;
 
+import com.github.barteksc.pdfviewer.util.PageViewType;
+
 
 /**
  * This manager is used by the PDFView to launch animations.
@@ -171,6 +173,8 @@ class AnimationManager {
 
         @Override
         public void onAnimationEnd(Animator animation) {
+            if (pdfView.getPageViewType() == PageViewType.SINGLE && pdfView.getZoom() == pdfView.getMinZoom())
+                pdfView.jumpTo(pdfView.getCurrentPage(), true);
             pdfView.loadPages();
             hideHandle();
         }

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DecodingAsyncTask.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DecodingAsyncTask.java
@@ -48,7 +48,7 @@ class DecodingAsyncTask extends AsyncTask<Void, Void, Throwable> {
         try {
             PdfDocument pdfDocument = docSource.createDocument(pdfView.getContext(), pdfiumCore, password);
             pdfFile = new PdfFile(pdfiumCore, pdfDocument, pdfView.getPageFitPolicy(), getViewSize(),
-                    userPages, pdfView.isSwipeVertical(), pdfView.getSpacingPx());
+                    userPages, pdfView.isSwipeVertical(), pdfView.getSpacingPx(), pdfView.getPageViewType());
             return null;
         } catch (Throwable t) {
             return t;

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
@@ -24,6 +24,7 @@ import android.view.View;
 
 import com.github.barteksc.pdfviewer.model.LinkTapEvent;
 import com.github.barteksc.pdfviewer.scroll.ScrollHandle;
+import com.github.barteksc.pdfviewer.util.PageViewType;
 import com.shockwave.pdfium.PdfDocument;
 import com.shockwave.pdfium.util.SizeF;
 
@@ -155,6 +156,8 @@ class DragPinchManager implements GestureDetector.OnGestureListener, GestureDete
     }
 
     private void onScrollEnd(MotionEvent event) {
+        if (pdfView.getPageViewType() == PageViewType.SINGLE && !pdfView.isZooming())
+          pdfView.jumpTo(pdfView.getCurrentPage(), true);
         pdfView.loadPages();
         hideHandle();
     }

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/util/PageViewType.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/util/PageViewType.java
@@ -1,0 +1,9 @@
+package com.github.barteksc.pdfviewer.util;
+
+/**
+ * Created by starnaus on 12/22/2017.
+ */
+
+public enum PageViewType {
+    CONTINUOUS, SINGLE
+}

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -13,11 +13,11 @@ repositories {
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'android-apt'
+//apply plugin: 'android-apt'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    //buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 11
@@ -31,6 +31,7 @@ android {
 dependencies {
     compile project(':android-pdf-viewer')
     compile 'com.android.support:appcompat-v7:25.3.1'
-    provided 'org.androidannotations:androidannotations:4.0.0'
+    annotationProcessor 'org.androidannotations:androidannotations:4.0.0'
+    //provided 'org.androidannotations:androidannotations:4.0.0'
     compile 'org.androidannotations:androidannotations-api:4.0.0'
 }

--- a/sample/src/main/java/com/github/barteksc/sample/PDFViewActivity.java
+++ b/sample/src/main/java/com/github/barteksc/sample/PDFViewActivity.java
@@ -35,6 +35,7 @@ import com.github.barteksc.pdfviewer.listener.OnPageChangeListener;
 import com.github.barteksc.pdfviewer.listener.OnPageErrorListener;
 import com.github.barteksc.pdfviewer.scroll.DefaultScrollHandle;
 import com.github.barteksc.pdfviewer.util.FitPolicy;
+import com.github.barteksc.pdfviewer.util.PageViewType;
 import com.shockwave.pdfium.PdfDocument;
 
 import org.androidannotations.annotations.AfterViews;
@@ -46,6 +47,8 @@ import org.androidannotations.annotations.OptionsMenu;
 import org.androidannotations.annotations.ViewById;
 
 import java.util.List;
+
+import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
 
 @EActivity(R.layout.activity_main)
 @OptionsMenu(R.menu.options)
@@ -102,7 +105,7 @@ public class PDFViewActivity extends AppCompatActivity implements OnPageChangeLi
 
     @AfterViews
     void afterViews() {
-        pdfView.setBackgroundColor(Color.LTGRAY);
+        pdfView.setBackgroundColor(Color.BLACK);
         if (uri != null) {
             displayFromUri(uri);
         } else {
@@ -114,7 +117,7 @@ public class PDFViewActivity extends AppCompatActivity implements OnPageChangeLi
     private void displayFromAsset(String assetFileName) {
         pdfFileName = assetFileName;
 
-        pdfView.fromAsset(SAMPLE_FILE)
+        /*pdfView.fromAsset(SAMPLE_FILE)
                 .defaultPage(pageNumber)
                 .onPageChange(this)
                 .enableAnnotationRendering(true)
@@ -123,7 +126,23 @@ public class PDFViewActivity extends AppCompatActivity implements OnPageChangeLi
                 .spacing(10) // in dp
                 .onPageError(this)
                 .pageFitPolicy(FitPolicy.BOTH)
-                .load();
+                .load();*/
+
+        PDFView.Configurator configurator = pdfView.fromAsset(SAMPLE_FILE);
+        configurator.defaultPage(pageNumber);
+        configurator.onPageChange(this);
+        configurator.enableAnnotationRendering(true);
+        configurator.onLoad(this);
+        //configurator.scrollHandle(new DefaultScrollHandle(this));
+        //configurator.spacing(300);
+        configurator.onPageError(this);
+        configurator.swipeHorizontal(true);
+        configurator.pageViewType(PageViewType.SINGLE);
+        if (getResources().getConfiguration().orientation == ORIENTATION_LANDSCAPE)
+            configurator.pageFitPolicy(FitPolicy.HEIGHT);
+        else
+            configurator.pageFitPolicy(FitPolicy.WIDTH);
+        configurator.load();
     }
 
     private void displayFromUri(Uri uri) {


### PR DESCRIPTION
Added "PageViewType" with two available values: SINGLE or CONTINUOUS. Continuous behaves as it did before. Single will swipe one page at a time, centered in the viewer. Zooming will behave like Continuous in order to view the whole page (so it won't keep snapping to leading edge of page), until zoomed to min where it will re-center.