### PR TITLE
Add page snapping and single page fling

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,12 @@ pdfView.fromAsset(String)
     .enableAntialiasing(true) // improve rendering a little bit on low-res screens
     // spacing between pages in dp. To define spacing color, set view background
     .spacing(0)
+    .autoSpacing(false) // add dynamic spacing to fit each page on its own on the screen
     .linkHandler(DefaultLinkHandler)
     .pageFitPolicy(FitPolicy.WIDTH)
+    // choose of start, center or end. Pages are snapped to this edge after scroll.
+    .snapPolicy(SnapPolicy.NONE)
+    .pageFling(false) // make a fling change only a single page like ViewPager
     .load();
 ```
 
@@ -204,6 +208,15 @@ Configurator.onRender(new OnRenderListener() {
         pdfView.fitToWidth(pageIndex);
     }
 });
+```
+
+### How can I scroll through single pages like a ViewPager?
+You can use a combination of the following settings to get scroll and fling behaviour similiar to a ViewPager:
+``` java
+    .swipeHorizontal(true)
+    .snapPolicy(SnapPolicy.CENTER)
+    .autoSpacing(true)
+    .pageFling(true)
 ```
 
 ## One more thing

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/AnimationManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/AnimationManager.java
@@ -87,7 +87,7 @@ class AnimationManager {
         scroller.fling(startX, startY, velocityX, velocityY, minX, maxX, minY, maxY);
     }
 
-    public void startPageFlinfAnimation(float targetOffset) {
+    public void startPageFlingAnimation(float targetOffset) {
         if (pdfView.isSwipeVertical()) {
             startYAnimation(pdfView.getCurrentYOffset(), targetOffset);
         } else {

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/AnimationManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/AnimationManager.java
@@ -21,7 +21,6 @@ import android.animation.AnimatorListenerAdapter;
 import android.animation.ValueAnimator;
 import android.animation.ValueAnimator.AnimatorUpdateListener;
 import android.graphics.PointF;
-import android.view.MotionEvent;
 import android.view.animation.DecelerateInterpolator;
 import android.widget.OverScroller;
 
@@ -88,23 +87,11 @@ class AnimationManager {
         scroller.fling(startX, startY, velocityX, velocityY, minX, maxX, minY, maxY);
     }
 
-    public void startPageFlingAnimation(MotionEvent downEvent, MotionEvent ev, float velocityX, float velocityY) {
-        int direction;
-        if(pdfView.isSwipeVertical()) {
-            direction = velocityY > 0 ? -1 : 1;
-        } else {
-            direction = velocityX > 0 ? -1 : 1;
-        }
-        // get the focused page for the down event to ensure a single page is changed
-        float delta = pdfView.isSwipeVertical() ? ev.getY() - downEvent.getY() : ev.getX() - downEvent.getX();
-        int startingPage = pdfView.findPageToSnap(-delta * pdfView.getZoom());
-        int targetPage = Math.max(0, Math.min(pdfView.getPageCount() - 1, startingPage + direction));
-        float offset = pdfView.snapOffsetForPage(targetPage);
-
+    public void startPageFlinfAnimation(float targetOffset) {
         if (pdfView.isSwipeVertical()) {
-            startYAnimation(pdfView.getCurrentYOffset(), -offset);
+            startYAnimation(pdfView.getCurrentYOffset(), targetOffset);
         } else {
-            startXAnimation(pdfView.getCurrentXOffset(), -offset);
+            startXAnimation(pdfView.getCurrentXOffset(), targetOffset);
         }
         pageFlinging = true;
     }

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/AnimationManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/AnimationManager.java
@@ -116,8 +116,10 @@ class AnimationManager {
         } else if (flinging) { // fling finished
             flinging = false;
             pdfView.loadPages();
-            pdfView.doPageSnap();
             hideHandle();
+            if (!pdfView.isZooming()) {
+                pdfView.doPageSnap();
+            }
         }
     }
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DecodingAsyncTask.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DecodingAsyncTask.java
@@ -48,7 +48,7 @@ class DecodingAsyncTask extends AsyncTask<Void, Void, Throwable> {
         try {
             PdfDocument pdfDocument = docSource.createDocument(pdfView.getContext(), pdfiumCore, password);
             pdfFile = new PdfFile(pdfiumCore, pdfDocument, pdfView.getPageFitPolicy(), getViewSize(),
-                    userPages, pdfView.isSwipeVertical(), pdfView.getSpacingPx());
+                    userPages, pdfView.isSwipeVertical(), pdfView.getSpacingPx(), pdfView.doAutoSpacing());
             return null;
         } catch (Throwable t) {
             return t;

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
@@ -157,6 +157,7 @@ class DragPinchManager implements GestureDetector.OnGestureListener, GestureDete
 
     private void onScrollEnd(MotionEvent event) {
         pdfView.loadPages();
+        pdfView.doPageSnap();
         hideHandle();
     }
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
@@ -97,35 +97,13 @@ class DragPinchManager implements GestureDetector.OnGestureListener, GestureDete
         for (PdfDocument.Link link : pdfFile.getPageLinks(page)) {
             RectF mapped = pdfFile.mapRectToDevice(page, pageX, pageY, (int) pageSize.getWidth(),
                     (int) pageSize.getHeight(), link.getBounds());
-            fixCoords(mapped);
+            mapped.sort();
             if (mapped.contains(mappedX, mappedY)) {
                 pdfView.callbacks.callLinkHandler(new LinkTapEvent(x, y, mappedX, mappedY, mapped, link));
                 return true;
             }
         }
         return false;
-    }
-
-    /** Fix different coordinate axis */
-    private void fixCoords(RectF rect) {
-        if (rect.top > rect.bottom) {
-            swapTopBottom(rect);
-        }
-        if (rect.left > rect.right) {
-            swapLeftRight(rect);
-        }
-    }
-
-    private void swapTopBottom(RectF rect) {
-        float tmp = rect.top;
-        rect.top = rect.bottom;
-        rect.bottom = tmp;
-    }
-
-    private void swapLeftRight(RectF rect) {
-        float tmp = rect.left;
-        rect.left = rect.right;
-        rect.right = tmp;
     }
 
     @Override

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
@@ -126,7 +126,7 @@ class DragPinchManager implements GestureDetector.OnGestureListener, GestureDete
         int targetPage = Math.max(0, Math.min(pdfView.getPageCount() - 1, startingPage + direction));
 
         float offset = pdfView.snapOffsetForPage(targetPage);
-        animationManager.startPageFlinfAnimation(-offset);
+        animationManager.startPageFlingAnimation(-offset);
     }
 
     @Override

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
@@ -159,7 +159,7 @@ class DragPinchManager implements GestureDetector.OnGestureListener, GestureDete
     private void onScrollEnd(MotionEvent event) {
         pdfView.loadPages();
         hideHandle();
-        if(!animationManager.isFlinging()) {
+        if (!pdfView.isZooming() && !animationManager.isFlinging()) {
             pdfView.doPageSnap();
         }
     }
@@ -174,7 +174,7 @@ class DragPinchManager implements GestureDetector.OnGestureListener, GestureDete
         if (!pdfView.isSwipeEnabled()) {
             return false;
         }
-        if (pdfView.doPageFling()) {
+        if (!pdfView.isZooming() && pdfView.doPageFling()) {
             if (checkDoPageFling(velocityX, velocityY)) {
                 animationManager.startPageFlingAnimation(e1, e2, velocityX, velocityY);
             }

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -218,7 +218,7 @@ public class PDFView extends RelativeLayout {
     /** Spacing between pages, in px */
     private int spacingPx = 0;
 
-    /** Calculate spacing to fit a single page on screen. This overrides {@link #spacingPx}. */
+    /** Add dynamic spacing to fit each page separately on the screen. */
     private boolean autoSpacing = false;
 
     /** Fling a single page at a time */

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -215,6 +215,9 @@ public class PDFView extends RelativeLayout {
     /** Spacing between pages, in px */
     private int spacingPx = 0;
 
+    /** Calculate spacing to fit a single page on screen. This overrides {@link #spacingPx}. */
+    private boolean autoSpacing = false;
+
     /** Pages numbers used when calling onDrawAllListener */
     private List<Integer> onDrawPagesNums = new ArrayList<>(10);
 
@@ -274,7 +277,7 @@ public class PDFView extends RelativeLayout {
         }
 
         page = pdfFile.determineValidPageNumberFrom(page);
-        float offset = -pdfFile.getPageOffset(page, zoom);
+        float offset = page == 0 ? 0 : -pdfFile.getPageOffset(page, zoom);
         if (swipeVertical) {
             if (withAnimation) {
                 animationManager.startYAnimation(currentYOffset, offset);
@@ -1065,8 +1068,16 @@ public class PDFView extends RelativeLayout {
         return spacingPx;
     }
 
+    boolean doAutoSpacing() {
+        return autoSpacing;
+    }
+
     private void setSpacing(int spacing) {
         this.spacingPx = Util.getDP(getContext(), spacing);
+    }
+
+    private void setAutoSpacing(boolean autoSpacing) {
+        this.autoSpacing = autoSpacing;
     }
 
     private void setPageFitPolicy(FitPolicy pageFitPolicy) {
@@ -1181,6 +1192,8 @@ public class PDFView extends RelativeLayout {
 
         private int spacing = 0;
 
+        private boolean autoSpacing = false;
+
         private FitPolicy pageFitPolicy = FitPolicy.WIDTH;
 
         private Configurator(DocumentSource documentSource) {
@@ -1287,6 +1300,11 @@ public class PDFView extends RelativeLayout {
             return this;
         }
 
+        public Configurator autoSpacing(boolean autoSpacing) {
+            this.autoSpacing = autoSpacing;
+            return this;
+        }
+
         public Configurator pageFitPolicy(FitPolicy pageFitPolicy) {
             this.pageFitPolicy = pageFitPolicy;
             return this;
@@ -1316,6 +1334,7 @@ public class PDFView extends RelativeLayout {
             PDFView.this.setScrollHandle(scrollHandle);
             PDFView.this.enableAntialiasing(antialiasing);
             PDFView.this.setSpacing(spacing);
+            PDFView.this.setAutoSpacing(autoSpacing);
             PDFView.this.setPageFitPolicy(pageFitPolicy);
 
             if (pageNumbers != null) {

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
@@ -204,6 +204,11 @@ class PdfFile {
         return documentLength * zoom;
     }
 
+    public float getPageSpacing(int pageIndex, float zoom) {
+        float spacing = autoSpacing ? pageSpacing.get(pageIndex) : spacingPx;
+        return spacing * zoom;
+    }
+
     /** Get primary page offset, that is Y for vertical scroll and X for horizontal scroll */
     public float getPageOffset(int pageIndex, float zoom) {
         int docPage = documentPage(pageIndex);
@@ -227,13 +232,13 @@ class PdfFile {
 
     public int getPageAtOffset(float offset, float zoom) {
         int currentPage = 0;
-        for (float off : pageOffsets) {
-            if (off * zoom >= offset) {
+        for (int i = 0; i < getPagesCount(); i++) {
+            float off = pageOffsets.get(i) * zoom - getPageSpacing(i, zoom) / 2f;
+            if(off >= offset) {
                 break;
             }
             currentPage++;
         }
-
         return --currentPage >= 0 ? currentPage : 0;
     }
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
@@ -165,6 +165,9 @@ class PdfFile {
             SizeF pageSize = pageSizes.get(i);
             float spacing = isVertical ? viewSize.getHeight() - pageSize.getHeight() :
                     viewSize.getWidth() - pageSize.getWidth();
+            if (i < getPagesCount() - 1) {
+                spacing += spacingPx;
+            }
             pageSpacing.add(spacing);
         }
     }
@@ -191,6 +194,11 @@ class PdfFile {
             float size = isVertical ? pageSize.getHeight() : pageSize.getWidth();
             if (autoSpacing) {
                 offset += pageSpacing.get(i) / 2f;
+                if (i == 0) {
+                    offset -= spacingPx / 2f;
+                } else if (i == getPagesCount() - 1) {
+                    offset += spacingPx / 2f;
+                }
                 pageOffsets.add(offset);
                 offset += size + pageSpacing.get(i) / 2f;
             } else {

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
@@ -242,7 +242,7 @@ class PdfFile {
         int currentPage = 0;
         for (int i = 0; i < getPagesCount(); i++) {
             float off = pageOffsets.get(i) * zoom - getPageSpacing(i, zoom) / 2f;
-            if(off >= offset) {
+            if (off >= offset) {
                 break;
             }
             currentPage++;

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
@@ -51,10 +51,16 @@ class PdfFile {
     private SizeF maxHeightPageSize = new SizeF(0, 0);
     /** Scaled page with maximum width */
     private SizeF maxWidthPageSize = new SizeF(0, 0);
+    /** True if scrolling is vertical, else it's horizontal */
     private boolean isVertical = true;
+    /** Fixed spacing between pages in pixels */
     private int spacingPx = 0;
+    /** Calculate spacing automatically so each page fits on it's own in the center of the view */
+    private boolean autoSpacing;
     /** Calculated offsets for pages */
     private List<Float> pageOffsets = new ArrayList<>();
+    /** Calculated auto spacing for pages */
+    private List<Float> pageSpacing = new ArrayList<>();
     /** Calculated document length (width or height, depending on swipe mode) */
     private float documentLength = 0;
     private final FitPolicy pageFitPolicy;
@@ -65,13 +71,14 @@ class PdfFile {
     private int[] originalUserPages;
 
     PdfFile(PdfiumCore pdfiumCore, PdfDocument pdfDocument, FitPolicy pageFitPolicy, Size viewSize, int[] originalUserPages,
-            boolean isVertical, int spacing) {
+            boolean isVertical, int spacing, boolean autoSpacing) {
         this.pdfiumCore = pdfiumCore;
         this.pdfDocument = pdfDocument;
         this.pageFitPolicy = pageFitPolicy;
         this.originalUserPages = originalUserPages;
         this.isVertical = isVertical;
         this.spacingPx = spacing;
+        this.autoSpacing = autoSpacing;
         setup(viewSize);
     }
 
@@ -111,7 +118,9 @@ class PdfFile {
         for (Size size : originalPageSizes) {
             pageSizes.add(calculator.calculate(size));
         }
-
+        if (autoSpacing) {
+            prepareAutoSpacing(viewSize);
+        }
         prepareDocLen();
         preparePagesOffset();
     }
@@ -150,23 +159,44 @@ class PdfFile {
         return getMaxPageSize().getHeight();
     }
 
+    private void prepareAutoSpacing(Size viewSize) {
+        pageSpacing.clear();
+        for (int i = 0; i < getPagesCount(); i++) {
+            SizeF pageSize = pageSizes.get(i);
+            float spacing = isVertical ? viewSize.getHeight() - pageSize.getHeight() :
+                    viewSize.getWidth() - pageSize.getWidth();
+            pageSpacing.add(spacing);
+        }
+    }
+
     private void prepareDocLen() {
         float length = 0;
-        for (SizeF pageSize : pageSizes) {
+        for (int i = 0; i < getPagesCount(); i++) {
+            SizeF pageSize = pageSizes.get(i);
             length += isVertical ? pageSize.getHeight() : pageSize.getWidth();
+            if (autoSpacing) {
+                length += pageSpacing.get(i);
+            } else if (i < getPagesCount() - 1) {
+                length += spacingPx;
+            }
         }
-        int spacing = spacingPx * (pageSizes.size() - 1);
-        documentLength = length + spacing;
+        documentLength = length;
     }
 
     private void preparePagesOffset() {
         pageOffsets.clear();
         float offset = 0;
         for (int i = 0; i < getPagesCount(); i++) {
-            float spacing = i * spacingPx;
-            pageOffsets.add(offset + spacing);
-            SizeF size = pageSizes.get(i);
-            offset += isVertical ? size.getHeight() : size.getWidth();
+            SizeF pageSize = pageSizes.get(i);
+            float size = isVertical ? pageSize.getHeight() : pageSize.getWidth();
+            if (autoSpacing) {
+                offset += pageSpacing.get(i) / 2f;
+                pageOffsets.add(offset);
+                offset += size + pageSpacing.get(i) / 2f;
+            } else {
+                pageOffsets.add(offset);
+                offset += size + spacingPx;
+            }
         }
     }
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/scroll/DefaultScrollHandle.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/scroll/DefaultScrollHandle.java
@@ -224,9 +224,11 @@ public class DefaultScrollHandle extends RelativeLayout implements ScrollHandle 
                     pdfView.setPositionOffset(relativeHandlerMiddle / (float) getWidth(), false);
                 }
                 return true;
-            case MotionEvent.ACTION_CANCEL:
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_POINTER_UP:
+                pdfView.doPageSnap();
+                // fallthrough
+            case MotionEvent.ACTION_CANCEL:
                 hideDelayed();
                 return true;
         }

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/scroll/DefaultScrollHandle.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/scroll/DefaultScrollHandle.java
@@ -224,12 +224,11 @@ public class DefaultScrollHandle extends RelativeLayout implements ScrollHandle 
                     pdfView.setPositionOffset(relativeHandlerMiddle / (float) getWidth(), false);
                 }
                 return true;
+            case MotionEvent.ACTION_CANCEL:
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_POINTER_UP:
-                pdfView.doPageSnap();
-                // fallthrough
-            case MotionEvent.ACTION_CANCEL:
                 hideDelayed();
+                pdfView.doPageSnap();
                 return true;
         }
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/util/SnapPolicy.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/util/SnapPolicy.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2017 Bartosz Schiller
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.barteksc.pdfviewer.util;
+
+public enum SnapPolicy {
+    START, CENTER, END, NONE
+}


### PR DESCRIPTION
Adds options for 'paging' scroll behaviour.
Implemented as three features, which can be used separately or combined:

- Auto spacing: adds extra spacing per-page so that it fits on it's own centered in the screen.
- Snap policy: snap page to edge after scroll. Option of start, center, end or none.
- Page fling: on fling move only one page back or forwards.

When used all together and with horizontal swiping it acts similar to ViewPager.
The snap and fling features are disabled when zoomed in.