### PR TITLE
Add fitEachPage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ pdfView.fromAsset(String)
     .autoSpacing(false) // add dynamic spacing to fit each page on its own on the screen
     .linkHandler(DefaultLinkHandler)
     .pageFitPolicy(FitPolicy.WIDTH)
-    .pageSnap(true) // snap pages to screen boundaries
+    .fitEachPage(false) // fit each page to fill the view, disregarding relative size
+    .pageSnap(false) // snap pages to screen boundaries
     .pageFling(false) // make a fling change only a single page like ViewPager
     .load();
 ```

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ pdfView.fromAsset(String)
     .spacing(0)
     .autoSpacing(false) // add dynamic spacing to fit each page on its own on the screen
     .linkHandler(DefaultLinkHandler)
-    .pageFitPolicy(FitPolicy.WIDTH)
-    .fitEachPage(false) // fit each page to fill the view, disregarding relative size
+    .pageFitPolicy(FitPolicy.WIDTH) // mode to fit pages in the view
+    .fitEachPage(false) // fit each page to the view, else smaller pages are scaled relative to largest page.
     .pageSnap(false) // snap pages to screen boundaries
     .pageFling(false) // make a fling change only a single page like ViewPager
     .load();

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DecodingAsyncTask.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DecodingAsyncTask.java
@@ -48,8 +48,8 @@ class DecodingAsyncTask extends AsyncTask<Void, Void, Throwable> {
         try {
             PdfDocument pdfDocument = docSource.createDocument(pdfView.getContext(), pdfiumCore, password);
             pdfFile = new PdfFile(pdfiumCore, pdfDocument, pdfView.getPageFitPolicy(), getViewSize(),
-                    userPages, pdfView.isSwipeVertical(), pdfView.getSpacingPx(), pdfView.doAutoSpacing(),
-                    pdfView.doFitEachPage());
+                    userPages, pdfView.isSwipeVertical(), pdfView.getSpacingPx(), pdfView.isAutoSpacingEnabled(),
+                    pdfView.isFitEachPage());
             return null;
         } catch (Throwable t) {
             return t;

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DecodingAsyncTask.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DecodingAsyncTask.java
@@ -48,7 +48,8 @@ class DecodingAsyncTask extends AsyncTask<Void, Void, Throwable> {
         try {
             PdfDocument pdfDocument = docSource.createDocument(pdfView.getContext(), pdfiumCore, password);
             pdfFile = new PdfFile(pdfiumCore, pdfDocument, pdfView.getPageFitPolicy(), getViewSize(),
-                    userPages, pdfView.isSwipeVertical(), pdfView.getSpacingPx(), pdfView.doAutoSpacing());
+                    userPages, pdfView.isSwipeVertical(), pdfView.getSpacingPx(), pdfView.doAutoSpacing(),
+                    pdfView.doFitEachPage());
             return null;
         } catch (Throwable t) {
             return t;

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
@@ -197,7 +197,7 @@ class DragPinchManager implements GestureDetector.OnGestureListener, GestureDete
         if (!pdfView.isSwipeEnabled()) {
             return false;
         }
-        if (pdfView.doPageFling()) {
+        if (pdfView.isPageFlingEnabled()) {
             if (pdfView.pageFillsScreen()) {
                 onBoundedFling(velocityX, velocityY);
             } else {

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -168,6 +168,8 @@ public class PDFView extends RelativeLayout {
     /** Policy for fitting pages to screen */
     private FitPolicy pageFitPolicy = FitPolicy.WIDTH;
 
+    private boolean fitEachPage = false;
+
     private int defaultPage = 0;
 
     /** True if should scroll through pages vertically instead of horizontally */
@@ -1190,6 +1192,14 @@ public class PDFView extends RelativeLayout {
         return pageFitPolicy;
     }
 
+    private void setFitEachPage(boolean fitEachPage) {
+        this.fitEachPage = fitEachPage;
+    }
+
+    public boolean doFitEachPage() {
+        return fitEachPage;
+    }
+
     public boolean doPageSnap() {
         return pageSnap;
     }
@@ -1305,6 +1315,8 @@ public class PDFView extends RelativeLayout {
         private boolean autoSpacing = false;
 
         private FitPolicy pageFitPolicy = FitPolicy.WIDTH;
+
+        private boolean fitEachPage = false;
 
         private boolean pageFling = false;
 
@@ -1424,6 +1436,11 @@ public class PDFView extends RelativeLayout {
             return this;
         }
 
+        public Configurator fitEachPage(boolean fitEachPage) {
+            this.fitEachPage = fitEachPage;
+            return this;
+        }
+
         public Configurator pageSnap(boolean pageSnap) {
             this.pageSnap = pageSnap;
             return this;
@@ -1460,6 +1477,7 @@ public class PDFView extends RelativeLayout {
             PDFView.this.setSpacing(spacing);
             PDFView.this.setAutoSpacing(autoSpacing);
             PDFView.this.setPageFitPolicy(pageFitPolicy);
+            PDFView.this.setFitEachPage(fitEachPage);
             PDFView.this.setPageSnap(pageSnap);
             PDFView.this.setPageFling(pageFling);
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -1164,7 +1164,7 @@ public class PDFView extends RelativeLayout {
         return spacingPx;
     }
 
-    public boolean doAutoSpacing() {
+    public boolean isAutoSpacingEnabled() {
         return autoSpacing;
     }
 
@@ -1172,12 +1172,12 @@ public class PDFView extends RelativeLayout {
         this.pageFling = pageFling;
     }
 
-    public boolean doPageFling() {
+    public boolean isPageFlingEnabled() {
         return pageFling;
     }
 
-    private void setSpacing(int spacing) {
-        this.spacingPx = Util.getDP(getContext(), spacing);
+    private void setSpacing(int spacingDp) {
+        this.spacingPx = Util.getDP(getContext(), spacingDp);
     }
 
     private void setAutoSpacing(boolean autoSpacing) {
@@ -1196,11 +1196,11 @@ public class PDFView extends RelativeLayout {
         this.fitEachPage = fitEachPage;
     }
 
-    public boolean doFitEachPage() {
+    public boolean isFitEachPage() {
         return fitEachPage;
     }
 
-    public boolean doPageSnap() {
+    public boolean isPageSnap() {
         return pageSnap;
     }
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
@@ -52,9 +52,9 @@ class PdfFile {
     /** Scaled page with maximum width */
     private SizeF maxWidthPageSize = new SizeF(0, 0);
     /** True if scrolling is vertical, else it's horizontal */
-    private boolean isVertical = true;
+    private boolean isVertical;
     /** Fixed spacing between pages in pixels */
-    private int spacingPx = 0;
+    private int spacingPx;
     /** Calculate spacing automatically so each page fits on it's own in the center of the view */
     private boolean autoSpacing;
     /** Calculated offsets for pages */
@@ -64,6 +64,8 @@ class PdfFile {
     /** Calculated document length (width or height, depending on swipe mode) */
     private float documentLength = 0;
     private final FitPolicy pageFitPolicy;
+    /** If every page should fit to the screen as best as possible regardless of relative size */
+    private boolean fitEachPage;
     /**
      * The pages the user want to display in order
      * (ex: 0, 2, 2, 8, 8, 1, 1, 1)
@@ -71,7 +73,7 @@ class PdfFile {
     private int[] originalUserPages;
 
     PdfFile(PdfiumCore pdfiumCore, PdfDocument pdfDocument, FitPolicy pageFitPolicy, Size viewSize, int[] originalUserPages,
-            boolean isVertical, int spacing, boolean autoSpacing) {
+            boolean isVertical, int spacing, boolean autoSpacing, boolean fitEachPage) {
         this.pdfiumCore = pdfiumCore;
         this.pdfDocument = pdfDocument;
         this.pageFitPolicy = pageFitPolicy;
@@ -79,6 +81,7 @@ class PdfFile {
         this.isVertical = isVertical;
         this.spacingPx = spacing;
         this.autoSpacing = autoSpacing;
+        this.fitEachPage = fitEachPage;
         setup(viewSize);
     }
 
@@ -111,7 +114,7 @@ class PdfFile {
     public void recalculatePageSizes(Size viewSize) {
         pageSizes.clear();
         PageSizeCalculator calculator = new PageSizeCalculator(pageFitPolicy, originalMaxWidthPageSize,
-                originalMaxHeightPageSize, viewSize);
+                originalMaxHeightPageSize, viewSize, fitEachPage);
         maxWidthPageSize = calculator.getOptimalMaxWidthPageSize();
         maxHeightPageSize = calculator.getOptimalMaxHeightPageSize();
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PdfFile.java
@@ -64,8 +64,11 @@ class PdfFile {
     /** Calculated document length (width or height, depending on swipe mode) */
     private float documentLength = 0;
     private final FitPolicy pageFitPolicy;
-    /** If every page should fit to the screen as best as possible regardless of relative size */
-    private boolean fitEachPage;
+    /**
+     * True if every page should fit separately according to the FitPolicy,
+     * else the largest page fits and other pages scale relatively
+     */
+    private final boolean fitEachPage;
     /**
      * The pages the user want to display in order
      * (ex: 0, 2, 2, 8, 8, 1, 1, 1)

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/util/PageSizeCalculator.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/util/PageSizeCalculator.java
@@ -28,13 +28,15 @@ public class PageSizeCalculator {
     private SizeF optimalMaxHeightPageSize;
     private float widthRatio;
     private float heightRatio;
+    private boolean fitEachPage;
 
     public PageSizeCalculator(FitPolicy fitPolicy, Size originalMaxWidthPageSize, Size originalMaxHeightPageSize,
-                              Size viewSize) {
+                              Size viewSize, boolean fitEachPage) {
         this.fitPolicy = fitPolicy;
         this.originalMaxWidthPageSize = originalMaxWidthPageSize;
         this.originalMaxHeightPageSize = originalMaxHeightPageSize;
         this.viewSize = viewSize;
+        this.fitEachPage = fitEachPage;
         calculateMaxPages();
     }
 
@@ -42,13 +44,15 @@ public class PageSizeCalculator {
         if (pageSize.getWidth() <= 0 || pageSize.getHeight() <= 0) {
             return new SizeF(0, 0);
         }
+        float maxWidth = fitEachPage ? viewSize.getWidth() : pageSize.getWidth() * widthRatio;
+        float maxHeight = fitEachPage ? viewSize.getHeight() : pageSize.getHeight() * heightRatio;
         switch (fitPolicy) {
             case HEIGHT:
-                return fitHeight(pageSize, pageSize.getHeight() * heightRatio);
+                return fitHeight(pageSize, maxHeight);
             case BOTH:
-                return fitBoth(pageSize, pageSize.getWidth() * widthRatio, pageSize.getHeight() * heightRatio);
+                return fitBoth(pageSize, maxWidth, maxHeight);
             default:
-                return fitWidth(pageSize, pageSize.getWidth() * widthRatio);
+                return fitWidth(pageSize, maxWidth);
         }
     }
 


### PR DESCRIPTION
Adds a property to define how pages should be fit to the view:  

- **default**: The largest page is fit to the view and smaller pages are scaled relative to size.  
This is the most 'correct' way as pages appear as their real size. But it may waste space on the screen especially if there is only one oddly-sized page in the document.  
Note: this is only really a problem if `autoSpacing` is enabled, as otherwise the space is used for the next and previous pages.  
- **fitEachPage**: Each page is fit the the view according to the set FitPolicy.  
Optimise screen space by fitting each page separately, but may cause pages to appear larger/smaller relative to each other than they actually are.  

Additionally, this renames some getters from the previous pull request (#557) to be more boolean-like. 
  (e.g. `isAutoSpacingEnabled()` instead of `doAutoSpacing()`)

