### PR TITLE
Hide handle after animation

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/AnimationManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/AnimationManager.java
@@ -138,12 +138,14 @@ class AnimationManager {
         public void onAnimationCancel(Animator animation) {
             pdfView.loadPages();
             pageFlinging = false;
+            hideHandle();
         }
 
         @Override
         public void onAnimationEnd(Animator animation) {
             pdfView.loadPages();
             pageFlinging = false;
+            hideHandle();
         }
     }
 
@@ -160,12 +162,14 @@ class AnimationManager {
         public void onAnimationCancel(Animator animation) {
             pdfView.loadPages();
             pageFlinging = false;
+            hideHandle();
         }
 
         @Override
         public void onAnimationEnd(Animator animation) {
             pdfView.loadPages();
             pageFlinging = false;
+            hideHandle();
         }
     }
 
@@ -187,13 +191,15 @@ class AnimationManager {
 
         @Override
         public void onAnimationCancel(Animator animation) {
+            pdfView.loadPages();
+            hideHandle();
         }
 
         @Override
         public void onAnimationEnd(Animator animation) {
             pdfView.loadPages();
-            hideHandle();
             pdfView.performPageSnap();
+            hideHandle();
         }
 
         @Override


### PR DESCRIPTION
Hide the handle after an x, y or zoom animation.  
This fixes #574 but also makes sure the handle is correctly hidden after a user calls `pdfView.jumpTo()` with animation.