### PR TITLE
removing render thread onViewDetach to avoid problem with too high th…

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -30,6 +30,7 @@ import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.HandlerThread;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -154,7 +155,7 @@ public class PDFView extends RelativeLayout {
     private DecodingAsyncTask decodingAsyncTask;
 
     /** The thread {@link #renderingHandler} will run on */
-    private final HandlerThread renderingHandlerThread;
+    private HandlerThread renderingHandlerThread;
     /** Handler always waiting in the background and rendering tasks */
     RenderingHandler renderingHandler;
 
@@ -462,6 +463,14 @@ public class PDFView extends RelativeLayout {
     @Override
     protected void onDetachedFromWindow() {
         recycle();
+        if (renderingHandlerThread != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                renderingHandlerThread.quitSafely();
+            } else {
+                renderingHandlerThread.quit();
+            }
+            renderingHandlerThread = null;
+        }
         super.onDetachedFromWindow();
     }
 


### PR DESCRIPTION
New HandlerThread creating after each configuration change (e.g. screen rotation). Too many threads can cause crash. How to check (difficult but clear way):
1. Update build tools and run Profiler to check CPU load.
2. Run sample and click to CPU load timeline. Check current threads count.
3. Rotate device. Check current threads count.
Actual result: threads count increased on each config change.
Expected result: old HandlerThread should be released.

Simple way:
Run sample. Rotate device 200 times. Crash.

In this pull request I implemented releasing HandlerThread onDetachedFromWindow of PDFView.