### PR TITLE
Adding null check for the rendering handler thread

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -753,7 +753,7 @@ public class PDFView extends RelativeLayout {
 
         this.pdfFile = pdfFile;
 
-        if (!renderingHandlerThread.isAlive()) {
+        if (renderingHandlerThread != null && !renderingHandlerThread.isAlive()) {
             renderingHandlerThread.start();
         }
         renderingHandler = new RenderingHandler(renderingHandlerThread.getLooper(), this);


### PR DESCRIPTION
This will prevent the app from crashing if the rendering thread is null when the loading is complete