### PR TITLE
Move handler creation to onAttachedToWindow() instead of the constructor

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -245,8 +245,6 @@ public class PDFView extends RelativeLayout {
     public PDFView(Context context, AttributeSet set) {
         super(context, set);
 
-        renderingHandlerThread = new HandlerThread("PDF renderer");
-
         if (isInEditMode()) {
             return;
         }
@@ -460,6 +458,12 @@ public class PDFView extends RelativeLayout {
             return;
         }
         animationManager.computeFling();
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        renderingHandlerThread = new HandlerThread("PDF renderer");
     }
 
     @Override


### PR DESCRIPTION
Detaching and reattaching a `PDFView` causes an NPE. This is due to creating a handler in the constructor, but setting it to null in `onDetachedFromWindow()`. The fix is to create the handler on `onAttachedToWindow()` instead of the constructor.

This allows the view to be detached and re-attached without loss of functionality.