### PR TITLE
bug fix(issue #834): PdfView#loadComplete(), line 756, renderingHandlerThread NullPointerException

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -753,6 +753,10 @@ public class PDFView extends RelativeLayout {
 
         this.pdfFile = pdfFile;
 
+        if (renderingHandlerThread == null) {
+            return;
+        }
+
         if (!renderingHandlerThread.isAlive()) {
             renderingHandlerThread.start();
         }


### PR DESCRIPTION
Bug arises when user opens activity and closes immediately many times in a row. I guess when user closes activity, it calls method onDetachedFromWindow() where renderingHandlerThread variable is equaled to null. So it is needed to check in loadComplete() method if renderingHandlerThread is null.